### PR TITLE
Remove logging options on token fetch

### DIFF
--- a/src/tokenAuthProvider.ts
+++ b/src/tokenAuthProvider.ts
@@ -63,7 +63,6 @@ export function createOptionsFromToken() {
 }
 
 export function fetchJsonWithAuthToken(url: string, options: object) {
-  console.log(options);
   return fetchUtils.fetchJson(
     url,
     Object.assign(createOptionsFromToken(), options)


### PR DESCRIPTION
I believe the console.log was left here by mistake.