### PR TITLE
Returning an empty array in deleteMany method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,6 @@ export default (
             method: 'DELETE',
           })
         )
-      ).then(responses => ({ data: responses.map(({ json }) => json.id) })),
+      ).then(() => ({ data: [] })),
   };
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -171,7 +171,7 @@ describe('dataProvider', () => {
       expect(
         await dataProvider.deleteMany('posts', { ids: [item.id] })
       ).toEqual({
-        data: [item.id],
+        data: [],
       });
     });
   });


### PR DESCRIPTION
deleteMany method returns an empty array instead of list of ids as django rest framework returns an empty response after deletion request